### PR TITLE
Update documentation in torchcfm

### DIFF
--- a/torchcfm/conditional_flow_matching.py
+++ b/torchcfm/conditional_flow_matching.py
@@ -49,7 +49,7 @@ class ConditionalFlowMatcher:
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
 
         Returns
         -------
@@ -72,7 +72,7 @@ class ConditionalFlowMatcher:
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
 
         Returns
         -------
@@ -95,7 +95,7 @@ class ConditionalFlowMatcher:
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
         epsilon : Tensor, shape (bs, dim)
             noise sample from N(0, 1)
 
@@ -122,7 +122,7 @@ class ConditionalFlowMatcher:
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
         xt : Tensor, shape (bs, dim)
             represents the samples drawn from probability path pt
 
@@ -157,7 +157,7 @@ class ConditionalFlowMatcher:
 
         Returns
         -------
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
         xt : Tensor, shape (bs, dim)
             represents the samples drawn from probability path pt
         ut : conditional vector field ut(x1|x0) = x1 - x0
@@ -181,7 +181,7 @@ class ConditionalFlowMatcher:
 
         Parameters
         ----------
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
 
         Returns
         -------
@@ -231,7 +231,7 @@ class ExactOptimalTransportConditionalFlowMatcher(ConditionalFlowMatcher):
 
         Returns
         -------
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
         xt : Tensor, shape (bs, dim)
             represents the samples drawn from probability path pt
         ut : conditional vector field ut(x1|x0) = x1 - x0
@@ -262,7 +262,7 @@ class TargetConditionalFlowMatcher(ConditionalFlowMatcher):
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
 
         Returns
         -------
@@ -285,7 +285,7 @@ class TargetConditionalFlowMatcher(ConditionalFlowMatcher):
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
 
         Returns
         -------
@@ -307,7 +307,7 @@ class TargetConditionalFlowMatcher(ConditionalFlowMatcher):
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
         xt : Tensor, shape (bs, dim)
             represents the samples drawn from probability path pt
 
@@ -355,7 +355,7 @@ class SchrodingerBridgeConditionalFlowMatcher(ConditionalFlowMatcher):
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
 
         Returns
         -------
@@ -379,7 +379,7 @@ class SchrodingerBridgeConditionalFlowMatcher(ConditionalFlowMatcher):
             represents the source minibatch
         x1 : Tensor, shape (bs, dim)
             represents the source minibatch
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
         xt : Tensor, shape (bs, dim)
             represents the samples drawn from probability path pt
 
@@ -417,7 +417,7 @@ class SchrodingerBridgeConditionalFlowMatcher(ConditionalFlowMatcher):
 
         Returns
         -------
-        t : float, shape (bs, 1)
+        t : float, shape (bs)
         xt : Tensor, shape (bs, dim)
             represents the samples drawn from probability path pt
         ut : conditional vector field ut(x1|x0) = x1 - x0


### PR DESCRIPTION
## What does this PR do?

There are some typos within the current documentation and the documentation of some functions is missing. This PR is to fix them.

Examples:
- [x] variable t dimension is (bs) not (bs,1)
- pad_t_like_x doc is missing
- VariancePreservingConditionalFlowMatcher documentation is missing