### PR TITLE
Update torchdyn requirement and actions versions

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -3,9 +3,6 @@
 
 name: Code Quality Main
 
-env:
-  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
-
 on:
   push:
     branches: [main]

--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false
+     fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10"]
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
-     fail-fast: false
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     timeout-minutes: 10
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,5 @@
 name: Tests
 
-env:
-  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
-
 on:
   push:
     branches: [main]
@@ -18,8 +15,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-
-    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install torch
           pip install -r requirements.txt
           pip install pytest
           pip install sh
@@ -57,6 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install torch
           pip install -r requirements.txt
           pip install pytest
           pip install pytest-cov[toml]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, windows-latest]
+        os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r runner-requirements.txt
           pip install pytest
           pip install sh
           pip install -e .
@@ -57,7 +57,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r runner-requirements.txt
           pip install pytest
           pip install pytest-cov[toml]
           pip install sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch
+          # Install cpu versions
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install pytest
           pip install sh
@@ -58,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install pytest
           pip install pytest-cov[toml]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: Tests
 
+env:
+  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, ubuntu-20.04, windows-latest]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,5 @@
 name: Tests
 
-env:
-  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
-
 on:
   push:
     branches: [main]
@@ -23,11 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -36,8 +28,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # Install cpu versions
-          # pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install pytest
           pip install sh
@@ -49,7 +39,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest -v
+          pytest -v runner
 
   # upload code coverage report
   code-coverage:
@@ -59,11 +49,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
-
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -72,7 +57,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install pytest
           pip install pytest-cov[toml]
@@ -80,7 +64,7 @@ jobs:
           pip install -e .
 
       - name: Run tests and collect coverage
-        run: pytest --cov src # NEEDS TO BE UPDATED WHEN CHANGING THE NAME OF "src" FOLDER
+        run: pytest runner --cov runner # NEEDS TO BE UPDATED WHEN CHANGING THE NAME OF "src" FOLDER
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Install cpu versions
-          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          # pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install pytest
           pip install sh
@@ -62,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          # pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements.txt
           pip install pytest
           pip install pytest-cov[toml]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -53,6 +58,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v4

--- a/examples/cifar10/train_cifar10.py
+++ b/examples/cifar10/train_cifar10.py
@@ -6,11 +6,12 @@ import torch
 from timm import scheduler
 from torchdyn.core import NeuralODE
 from torchvision import datasets, transforms
-from torchvision.transforms import ToPILImage
 from torchvision.utils import make_grid
 from tqdm import tqdm
 
-from torchcfm.conditional_flow_matching import *
+from torchcfm.conditional_flow_matching import (
+    ExactOptimalTransportConditionalFlowMatcher,
+)
 from torchcfm.models.unet.unet import UNetModelWrapper
 
 savedir = "weights/reproduced/"
@@ -99,7 +100,10 @@ with torch.no_grad():
         t_span=torch.linspace(0, 1, 100).to(device),
     )
 grid = make_grid(
-    traj[-1, :].view([-1, 3, 32, 32]).clip(-1, 1), value_range=(-1, 1), padding=0, nrow=10
+    traj[-1, :].view([-1, 3, 32, 32]).clip(-1, 1),
+    value_range=(-1, 1),
+    padding=0,
+    nrow=10,
 )
 
 img = grid.detach().cpu() / 2 + 0.5  # unnormalize

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
-lightning-bolts<=0.6.0
+lightning-bolts<=0.5.0
 matplotlib
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu113
 # pip install -r requirements.txt
 # --------- pytorch --------- #
-torch>=1.11.0
+torch>=1.11.0,<2.0.0
 torchvision>=0.11.0
 pytorch-lightning==1.8.3
 torchmetrics==0.11.0
@@ -36,7 +36,7 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
-lightning-bolts>=0.7.0
+lightning-bolts
 matplotlib
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
-lightning-bolts
+# lightning-bolts
 matplotlib
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ torchmetrics==0.11.0
 hydra-core==1.2.0
 hydra-colorlog==1.2.0
 hydra-optuna-sweeper==1.2.0
-hydra-submitit-launcher
+# hydra-submitit-launcher
 
 # --------- loggers --------- #
 wandb
@@ -36,16 +36,18 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
-lightning-bolts
 matplotlib
 numpy
 scipy
 scikit-learn
 torchdyn>=1.0.5   # 1.0.4 is broken on pypi
 pot
-scprep
-scanpy
-timm
+
+# -------- optional requirements ------- # 
+# lightning-bolts
+# scprep
+# scanpy
+# timm
 
 # --------- notebook reqs -------- #
 seaborn>=0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
-lightning-bolts<=0.5.0
+lightning-bolts>=0.7.0
 matplotlib
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,18 +36,16 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
+lightning-bolts
 matplotlib
 numpy
 scipy
 scikit-learn
+scprep
+scanpy
+timm
 torchdyn>=1.0.5   # 1.0.4 is broken on pypi
 pot
-
-# -------- optional requirements ------- # 
-# lightning-bolts
-# scprep
-# scanpy
-# timm
 
 # --------- notebook reqs -------- #
 seaborn>=0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,8 @@ scikit-learn
 scprep
 scanpy
 timm
-torchdyn>=1.0.5   # 1.0.4 is broken on pypi
+torchdyn==1.0.3   # 1.0.4 is broken on pypi
+#torchdyn>=1.0.5   # 1.0.4 is broken on pypi
 pot
 
 # --------- notebook reqs -------- #

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,8 +38,6 @@ pytest            # tests
 # --------- pkg reqs -------- #
 matplotlib
 numpy
-# sdeint
-torchdyn==1.0.3 # version 1.0.4 is broken
 scipy
 scikit-learn
 pot

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
-# lightning-bolts
+lightning-bolts<=0.6.0
 matplotlib
 numpy
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,41 +1,6 @@
-# Note if using Conda it is recommended to install torch separately.
-# For most of testing the following commands were run to set up the environment
-# This was tested with torch==1.12.1
-# conda create -n ti-env python=3.10
-# conda activate ti-env
-# pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu113
-# pip install -r requirements.txt
-# --------- pytorch --------- #
-torch>=1.11.0,<2.0.0
+torch>=1.11.0
 torchvision>=0.11.0
-pytorch-lightning==1.8.3
-torchmetrics==0.11.0
 
-# --------- hydra --------- #
-hydra-core==1.2.0
-hydra-colorlog==1.2.0
-hydra-optuna-sweeper==1.2.0
-# hydra-submitit-launcher
-
-# --------- loggers --------- #
-wandb
-# neptune-client
-# mlflow
-# comet-ml
-
-# --------- others --------- #
-black
-isort
-flake8
-Flake8-pyproject  # for configuration via pyproject
-pyrootutils       # standardizing the project root setup
-pre-commit        # hooks for applying linters on commit
-rich              # beautiful text formatting in terminal
-pytest            # tests
-# sh              # for running bash commands in some tests (linux/macos only)
-
-
-# --------- pkg reqs -------- #
 lightning-bolts
 matplotlib
 numpy
@@ -46,7 +11,3 @@ scanpy
 timm
 torchdyn>=1.0.5   # 1.0.4 is broken on pypi
 pot
-
-# --------- notebook reqs -------- #
-seaborn>=0.12.2
-pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ matplotlib
 numpy
 scipy
 scikit-learn
-torchdyn
+torchdyn!=1.0.4   # 1.0.4 is broken on pypi
 pot
 scprep
 scanpy
@@ -50,5 +50,3 @@ timm
 # --------- notebook reqs -------- #
 seaborn>=0.12.2
 pandas
-
-# git+https://github.com/patrick-kidger/torchcubicspline.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,18 +36,19 @@ pytest            # tests
 
 
 # --------- pkg reqs -------- #
+lightning-bolts
 matplotlib
 numpy
 scipy
 scikit-learn
+torchdyn
 pot
 scprep
 scanpy
-lightning-bolts
 timm
 
 # --------- notebook reqs -------- #
 seaborn>=0.12.2
 pandas
 
-git+https://github.com/patrick-kidger/torchcubicspline.git
+# git+https://github.com/patrick-kidger/torchcubicspline.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,7 @@ scikit-learn
 scprep
 scanpy
 timm
-torchdyn==1.0.3   # 1.0.4 is broken on pypi
-#torchdyn>=1.0.5   # 1.0.4 is broken on pypi
+torchdyn>=1.0.5   # 1.0.4 is broken on pypi
 pot
 
 # --------- notebook reqs -------- #

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ matplotlib
 numpy
 scipy
 scikit-learn
-torchdyn!=1.0.4   # 1.0.4 is broken on pypi
+torchdyn>=1.0.5   # 1.0.4 is broken on pypi
 pot
 scprep
 scanpy

--- a/runner-requirements.txt
+++ b/runner-requirements.txt
@@ -1,0 +1,52 @@
+# Note if using Conda it is recommended to install torch separately.
+# For most of testing the following commands were run to set up the environment
+# This was tested with torch==1.12.1
+# conda create -n ti-env python=3.10
+# conda activate ti-env
+# pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu113
+# pip install -r requirements.txt
+# --------- pytorch --------- #
+torch>=1.11.0,<2.0.0
+torchvision>=0.11.0
+pytorch-lightning==1.8.3
+torchmetrics==0.11.0
+
+# --------- hydra --------- #
+hydra-core==1.2.0
+hydra-colorlog==1.2.0
+hydra-optuna-sweeper==1.2.0
+# hydra-submitit-launcher
+
+# --------- loggers --------- #
+wandb
+# neptune-client
+# mlflow
+# comet-ml
+
+# --------- others --------- #
+black
+isort
+flake8
+Flake8-pyproject  # for configuration via pyproject
+pyrootutils       # standardizing the project root setup
+pre-commit        # hooks for applying linters on commit
+rich              # beautiful text formatting in terminal
+pytest            # tests
+# sh              # for running bash commands in some tests (linux/macos only)
+
+
+# --------- pkg reqs -------- #
+lightning-bolts
+matplotlib
+numpy
+scipy
+scikit-learn
+scprep
+scanpy
+timm
+torchdyn>=1.0.5   # 1.0.4 is broken on pypi
+pot
+
+# --------- notebook reqs -------- #
+seaborn>=0.12.2
+pandas

--- a/runner/src/models/components/augmentation.py
+++ b/runner/src/models/components/augmentation.py
@@ -273,7 +273,7 @@ class AugmentedVectorField(nn.Module):
         self.dim = dim
         self.augmentation_list = augmentation_list
 
-    def forward(self, t, state, augmented_input=True):
+    def forward(self, t, state, augmented_input=True, *args, **kwargs):
         n_aug = len(self.augmentation_list)
 
         class SharedContext:

--- a/runner/src/models/components/simple_mlp.py
+++ b/runner/src/models/components/simple_mlp.py
@@ -50,7 +50,7 @@ class DivergenceFreeNet(SimpleDenseNet):
     def energy(self, x):
         return self.model(x)
 
-    def forward(self, t, x):
+    def forward(self, t, x, *args, **kwargs):
         """Ignore t run model."""
         if t.dim() < 2:
             t = t.repeat(x.shape[0])[:, None]
@@ -64,7 +64,7 @@ class TimeInvariantVelocityNet(SimpleDenseNet):
     def __init__(self, dim: int, *args, **kwargs):
         super().__init__(input_size=dim, target_size=dim, *args, **kwargs)
 
-    def forward(self, t, x):
+    def forward(self, t, x, *args, **kwargs):
         """Ignore t run model."""
         del t
         return self.model(x)
@@ -74,7 +74,7 @@ class VelocityNet(SimpleDenseNet):
     def __init__(self, dim: int, *args, **kwargs):
         super().__init__(input_size=dim + 1, target_size=dim, *args, **kwargs)
 
-    def forward(self, t, x):
+    def forward(self, t, x, *args, **kwargs):
         """Ignore t run model."""
         if t.dim() < 1 or t.shape[0] != x.shape[0]:
             t = t.repeat(x.shape[0])[:, None]

--- a/runner/src/utils/__init__.py
+++ b/runner/src/utils/__init__.py
@@ -1,6 +1,5 @@
 from src.utils.pylogger import get_pylogger
 from src.utils.rich_utils import enforce_tags, print_config_tree
-
 from src.utils.utils import (
     close_loggers,
     extras,

--- a/runner/src/utils/rich_utils.py
+++ b/runner/src/utils/rich_utils.py
@@ -8,7 +8,6 @@ from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf, open_dict
 from pytorch_lightning.utilities import rank_zero_only
 from rich.prompt import Prompt
-
 from src.utils import pylogger
 
 log = pylogger.get_pylogger(__name__)

--- a/runner/src/utils/utils.py
+++ b/runner/src/utils/utils.py
@@ -9,7 +9,6 @@ from omegaconf import DictConfig
 from pytorch_lightning import Callback
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.utilities import rank_zero_only
-
 from src.utils import pylogger, rich_utils
 
 log = pylogger.get_pylogger(__name__)


### PR DESCRIPTION
## What does this PR do?

Upgrade torchdyn in the requirements after release 1.0.5

Fixes #3 permanently

Fixes requirement to `torch<2.0.0` as `torch>=2.0.0` creates incompatibilities between torch 2 compatible lightning bolt versions and `pytorch-lightning=1.8.3` other utilities should work just fine.