### PR TITLE
add padding of t in TargetConditionalFlowMatcher

### DIFF
--- a/torchcfm/conditional_flow_matching.py
+++ b/torchcfm/conditional_flow_matching.py
@@ -326,6 +326,7 @@ class TargetConditionalFlowMatcher(ConditionalFlowMatcher):
         [2] Flow Matching for Generative Modelling, ICLR, Lipman et al.
         """
         del x0
+        t = pad_t_like_x(t, x1)
         return t * x1
 
     def compute_sigma_t(self, t):
@@ -369,6 +370,7 @@ class TargetConditionalFlowMatcher(ConditionalFlowMatcher):
         [1] Flow Matching for Generative Modelling, ICLR, Lipman et al.
         """
         del x0
+        t = pad_t_like_x(t, x1)
         return (x1 - (1 - self.sigma) * xt) / (1 - (1 - self.sigma) * t)
 
 


### PR DESCRIPTION
Hello and thank you so much for the great package :)
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Using the class TargetConditionalFlowMatcher results in the error:

```
[/usr/local/lib/python3.10/dist-packages/torchcfm/conditional_flow_matching.py](https://localhost:8080/#) in sample_xt(self, x0, x1, t, epsilon)
    121         [1] Improving and Generalizing Flow-Based Generative Models with minibatch optimal transport, Preprint, Tong et al.
    122         """
--> 123         mu_t = self.compute_mu_t(x0, x1, t)
    124         sigma_t = self.compute_sigma_t(t)
    125         sigma_t = pad_t_like_x(sigma_t, x0)

[/usr/local/lib/python3.10/dist-packages/torchcfm/conditional_flow_matching.py](https://localhost:8080/#) in compute_mu_t(***failed resolving arguments***)
    327         """
    328         del x0
--> 329         return t * x1
    330 
    331     def compute_sigma_t(self, t):

RuntimeError: The size of tensor a (256) must match the size of tensor b (2) at non-singleton dimension 1
```

To fix this I have added the call to the existing function "pad_t_like_x()" in both the "compute_mu()" and "compute_conditional_flow()" methods of the class. This does not introduce any dependency and solves the issue.

### Doubt about the performance of the modified class

I have tested the modified TargetConditionalFlowMatcher in the 8gaussians to moons example. With the changes, the training code works but the model does not converge. Performance is terrible when compared with the standard ConditionalFlowMatcher. I don't see how this could be a fault of this PR; is this a problem of the TargetFM algorithm itself? Still, I find it a bit strange that it is not capable of converging for this simple problem. My tests are collected [here](https://colab.research.google.com/drive/1iv_X_sJqNywH1LIvMu2R-TEjAFkQn2sC?usp=sharing).

Let me know if I can provide anything else,
Best regards,
Francesco

