### PR TITLE
add comment in `conditional_mnist.ipynb` for training FM

### DIFF
--- a/examples/images/conditional_mnist.ipynb
+++ b/examples/images/conditional_mnist.ipynb
@@ -66,6 +66,8 @@
     ").to(device)\n",
     "optimizer = torch.optim.Adam(model.parameters())\n",
     "FM = ConditionalFlowMatcher(sigma=sigma)\n",
+    "# Users can try target FM by changing the above line by\n",
+    "# FM = TargetConditionalFlowMatcher(sigma=sigma)\n",
     "node = NeuralODE(model, solver=\"dopri5\", sensitivity=\"adjoint\", atol=1e-4, rtol=1e-4)"
    ]
   },


### PR DESCRIPTION
This PR includes a "flag" `USE_ICFM` in `conditional_mnist.ipynb` (similar to what is done [here in `train_cifar10.py`](https://github.com/atong01/conditional-flow-matching/blob/main/examples/images/cifar10/train_cifar10.py#L127-L130)) to allow training both FM and ICFM. 

- [y] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [y] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [y] Did you **test your PR locally** with `pytest` command?
- [y] Did you **run pre-commit hooks** with `pre-commit run -a` command?