### PR TITLE
Fix type batch_size

### DIFF
--- a/examples/images/cifar10/compute_fid.py
+++ b/examples/images/cifar10/compute_fid.py
@@ -27,7 +27,7 @@ flags.DEFINE_string("integration_method", "dopri5", help="integration method to 
 flags.DEFINE_integer("step", 400000, help="training steps")
 flags.DEFINE_integer("num_gen", 50000, help="number of samples to generate")
 flags.DEFINE_float("tol", 1e-5, help="Integrator tolerance (absolute and relative)")
-flags.DEFINE_float("batch_size_fid", 1024, help="Batch size to compute FID")
+flags.DEFINE_integer("batch_size_fid", 1024, help="Batch size to compute FID")
 
 FLAGS(sys.argv)
 


### PR DESCRIPTION
## What does this PR do?

Fix the flag type of the `batch_size` variable.

I have an additional question for the `compute_fid.py` script:
- `gen_1_img` generates a batch of images
- `compute_fid` take itself the batch_size as an argument 

Is it batching twice? 

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
