### PR TITLE
Expose eps as a parameter in `sample_location_and_conditional_flow`

### DIFF
--- a/torchcfm/conditional_flow_matching.py
+++ b/torchcfm/conditional_flow_matching.py
@@ -155,7 +155,7 @@ class ConditionalFlowMatcher:
     def sample_noise_like(self, x):
         return torch.randn_like(x)
 
-    def sample_location_and_conditional_flow(self, x0, x1, t=None, return_noise=False):
+    def sample_location_and_conditional_flow(self, x0, x1, t=None, eps=None, return_noise=False):
         """
         Compute the sample xt (drawn from N(t * x1 + (1 - t) * x0, sigma))
         and the conditional vector field ut(x1|x0) = x1 - x0, see Eq.(15) [1].
@@ -189,7 +189,8 @@ class ConditionalFlowMatcher:
             t = torch.rand(x0.shape[0]).type_as(x0)
         assert len(t) == x0.shape[0], "t has to have batch size dimension"
 
-        eps = self.sample_noise_like(x0)
+        if eps is None:
+            eps = self.sample_noise_like(x0)
         xt = self.sample_xt(x0, x1, t, eps)
         ut = self.compute_conditional_flow(x0, x1, t, xt)
         if return_noise:


### PR DESCRIPTION
## What does this PR do?
Our use case requires controlling determinism. The `torchcfm` has two sampling-based calls that forward RNG state: `t` and `eps`. `t` is exposed to the user via an argument, but `eps` is not. This PR exposes `eps` to the user in case they want to set that.

This shouldn't break any existing behavior.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?
Yes!