### PR TITLE
added multithreading to OTPlanSampler for "exact" solver

### DIFF
--- a/torchcfm/optimal_transport.py
+++ b/torchcfm/optimal_transport.py
@@ -1,7 +1,7 @@
 import math
 import warnings
 from functools import partial
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import ot as pot
@@ -18,7 +18,7 @@ class OTPlanSampler:
         reg: float = 0.05,
         reg_m: float = 1.0,
         normalize_cost: bool = False,
-        num_threads: int | str = 1,
+        num_threads: Union[int, str] = 1,
         warn: bool = True,
     ) -> None:
         """Initialize the OTPlanSampler class.

--- a/torchcfm/optimal_transport.py
+++ b/torchcfm/optimal_transport.py
@@ -18,6 +18,7 @@ class OTPlanSampler:
         reg: float = 0.05,
         reg_m: float = 1.0,
         normalize_cost: bool = False,
+        num_threads: int | str = 1,
         warn: bool = True,
     ) -> None:
         """Initialize the OTPlanSampler class.
@@ -36,13 +37,16 @@ class OTPlanSampler:
             normalizes the cost matrix so that the maximum cost is 1. Helps
             stabilize Sinkhorn-based solvers. Should not be used in the vast
             majority of cases.
+        num_threads: int or str, optional
+            number of threads to use for the "exact" OT solver. If "max", uses
+            the maximum number of threads.
         warn: bool, optional
             if True, raises a warning if the algorithm does not converge
         """
         # ot_fn should take (a, b, M) as arguments where a, b are marginals and
         # M is a cost matrix
         if method == "exact":
-            self.ot_fn = pot.emd
+            self.ot_fn = partial(pot.emd, numThreads=num_threads)
         elif method == "sinkhorn":
             self.ot_fn = partial(pot.sinkhorn, reg=reg)
         elif method == "unbalanced":


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

This PR adds support for OpenMP multithreading via the `OTPlanSampler` on initialization for `method == "exact"`. Here's the [link](https://pythonot.github.io/all.html#ot.emd) for Python OT's documentation of the pot.emd method. 

On my HPC (AMD EPYC 7742 CPU, A100 GPU), running `num_threads=2` or `num_threads=4` gave up to 2x speedups. This is hardware dependent so the default value will be `num_threads=1`, as it has been. 

If you would like to test threading performance yourself, here's the code that I used:
```
import argparse 
import time 
import torch 
import numpy as np 
import multiprocessing
from functools import partial
from torchcfm.optimal_transport import OTPlanSampler 
from torchcfm.utils import sample_8gaussians, sample_moons
from tqdm import tqdm 


def parse_args():
   parser = argparse.ArgumentParser()
   parser.add_argument("--num_samples", type=int, default=500)
   parser.add_argument("--num_rounds", type=int, default=50)
   return parser.parse_args()


if __name__ == "__main__":
   args = parse_args()


   samplers = {}
   for num_threads in [1, 2, 4, 8, 16, 32, 64]:
       samplers[num_threads] = OTPlanSampler(method="exact", num_threads=num_threads)
   #samplers[-1] = OTPlanSampler(method="exact", num_threads="max")


   torch.manual_seed(42)
   np.random.seed(42)


   samples = []
   for _ in range(args.num_rounds):
       x0 = sample_8gaussians(args.num_samples)
       x1 = sample_moons(args.num_samples)
       samples.append((x0, x1))


   # Test with POT implementation
   times = {}
   for num_threads, sampler in samplers.items():
       start = time.time()
       for x0, x1 in tqdm(samples):
           sampler.get_map(x0, x1)
       times[num_threads] = (time.time() - start)
   print("="*50)
   print(f"Using POT Implementation, Num. Samples: {args.num_samples}, Num. Rounds: {args.num_rounds}") 
   print("="*50)
   for num_threads, _time in times.items():
       print(f"Num. Threads: {num_threads}, Time: {_time:.2f}s")
```

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?
