### PR TITLE
Avoid using `infiniteloop` in `train_cifar10_ddp.py`

### DIFF
--- a/examples/images/cifar10/README.md
+++ b/examples/images/cifar10/README.md
@@ -29,7 +29,7 @@ python3 train_cifar10.py --model "fm" --lr 2e-4 --ema_decay 0.9999 --batch_size 
 Note that you can train all our methods in parallel using multiple GPUs and DistributedDataParallel. You can do this by providing the number of GPUs, setting the parallel flag to True and providing the master address and port in the command line. As an example:
 
 ```bash
-torchrun --nproc_per_node=NUM_GPUS_YOU_HAVE train_cifar10_ddp.py --model "otcfm" --lr 2e-4 --ema_decay 0.9999 --batch_size 128 --total_steps 400001 --save_step 20000 --parallel True --master_addr "MASTER_ADDR" --master_port "MASTER_PORT"
+torchrun --standalone --nproc_per_node=NUM_GPUS_YOU_HAVE train_cifar10_ddp.py --model "otcfm" --lr 2e-4 --ema_decay 0.9999 --batch_size 128 --total_steps 400001 --save_step 20000 --parallel True --master_addr "MASTER_ADDR" --master_port "MASTER_PORT"
 ```
 
 To compute the FID from the OT-CFM model at end of training, run:

--- a/examples/images/cifar10/train_cifar10_ddp.py
+++ b/examples/images/cifar10/train_cifar10_ddp.py
@@ -164,7 +164,7 @@ def train(rank, total_num_gpus, argv):
 
             with trange(steps_per_epoch, dynamic_ncols=True) as step_pbar:
                 for step in step_pbar:
-                    global_step += step
+                    global_step += 1
 
                     optim.zero_grad()
                     x1 = next(datalooper).to(rank)

--- a/examples/images/cifar10/train_cifar10_ddp.py
+++ b/examples/images/cifar10/train_cifar10_ddp.py
@@ -15,7 +15,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DistributedSampler
 from torchdyn.core import NeuralODE
 from torchvision import datasets, transforms
-from utils_cifar import ema, generate_samples, infiniteloop, setup
+from utils_cifar import ema, generate_samples, setup
 
 from torchcfm.conditional_flow_matching import (
     ConditionalFlowMatcher,
@@ -101,8 +101,6 @@ def train(rank, total_num_gpus, argv):
         num_workers=FLAGS.num_workers,
         drop_last=True,
     )
-
-    datalooper = infiniteloop(dataloader)
 
     # Calculate number of epochs
     steps_per_epoch = math.ceil(len(dataset) / FLAGS.batch_size)


### PR DESCRIPTION
## What does this PR do?

This PR avoids using infinite generator provided by `infiniteloop` and directly use the `dataloader` instead as discussed in #144. This change follows [the structure provided by `pytorch`](https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler).

I tested the change locally and make sure that it can run smoothly.

I also added a `--standalone` command line argument in README, without which I cannot make the script run. This argument is also provided by [the official example for single node usage](https://pytorch.org/docs/stable/elastic/run.html#usage).

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
