### PR TITLE
Checkpointing flag of Attention Block is not correctly set up

### DIFF
--- a/torchcfm/models/unet/unet.py
+++ b/torchcfm/models/unet/unet.py
@@ -270,7 +270,7 @@ class AttentionBlock(nn.Module):
         self.proj_out = zero_module(conv_nd(1, channels, channels, 1))
 
     def forward(self, x):
-        return checkpoint(self._forward, (x,), self.parameters(), True)
+        return checkpoint(self._forward, (x,), self.parameters(), self.use_checkpoint)
 
     def _forward(self, x):
         b, c, *spatial = x.shape


### PR DESCRIPTION
## Checkpointing flag of Attention Block is not correctly set up

The Attention Block was always using checkpointing by setting the flag to True. This pull request fixes this issue by respecting the use_checkpoint parameter.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
