### PR TITLE
Small documentation fix

### DIFF
--- a/torchcfm/optimal_transport.py
+++ b/torchcfm/optimal_transport.py
@@ -69,7 +69,7 @@ class OTPlanSampler:
         x0 : Tensor, shape (bs, *dim)
             represents the source minibatch
         x1 : Tensor, shape (bs, *dim)
-            represents the source minibatch
+            represents the target minibatch
 
         Returns
         -------


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Corrected the x1 parameter description in get_map docstring to refer to the target minibatch. Fixing #173 