### PR TITLE
Fixed example notebook links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ List of implemented papers:
 
 Run a simple minimal example here [![Run in Google Colab](https://img.shields.io/static/v1?label=Run%20in&message=Google%20Colab&color=orange&logo=Google%20Cloud)](https://colab.research.google.com/github/atong01/conditional-flow-matching/blob/master/examples/2D_tutorials/tutorial_training_8_gaussians_to_moons.ipynb). Or install the more efficient code locally with these steps.
 
-TorchCFM is now on [pypi](https://pypi.org/project/torchcfm/)! You can install it with:
+TorchCFM is now on [PyPI](https://pypi.org/project/torchcfm/)! You can install it with:
 
 ```bash
 pip install torchcfm

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Conditional Flow Matching (CFM) is a fast way to train continuous normalizing fl
 
 The density, vector field, and trajectories of simulation-free CNF training schemes: mapping 8 Gaussians to two moons (above) and a single Gaussian to two moons (below). Action matching with the same architecture (3x64 MLP with SeLU activations) underfits with the ReLU, SiLU, and SiLU activations as suggested in the [example code](https://github.com/necludov/jam), but it seems to fit better under our training setup (Action-Matching (Swish)).
 
-The models to produce the GIFs are stored in `examples/models` and can be visualized with this notebook: [![notebook](https://img.shields.io/static/v1?label=Run%20in&message=Google%20Colab&color=orange&logo=Google%20Cloud)](https://colab.research.google.com/github/atong01/conditional-flow-matching/blob/master/examples/notebooks/model-comparison-plotting.ipynb).
+The GIF above is produced by the `examples/2D_tutorials/model-comparison-plotting.ipynb` notebook: [![notebook](https://img.shields.io/static/v1?label=Run%20in&message=Google%20Colab&color=orange&logo=Google%20Cloud)](https://colab.research.google.com/github/atong01/conditional-flow-matching/blob/master/examples/2D_tutorials/model-comparison-plotting.ipynb).
 
-We also have included an example of unconditional MNIST generation in `examples/notebooks/mnist_example.ipynb` for both deterministic and stochastic generation. [![notebook](https://img.shields.io/static/v1?label=Run%20in&message=Google%20Colab&color=orange&logo=Google%20Cloud)](https://colab.research.google.com/github/atong01/conditional-flow-matching/blob/master/examples/notebooks/mnist_example.ipynb).
+We also have included an example of unconditional MNIST generation in `examples/images/mnist_example.ipynb` for both deterministic and stochastic generation. [![notebook](https://img.shields.io/static/v1?label=Run%20in&message=Google%20Colab&color=orange&logo=Google%20Cloud)](https://colab.research.google.com/github/atong01/conditional-flow-matching/blob/master/examples/images/mnist_example.ipynb).
 
 ## The torchcfm Package
 
@@ -117,7 +117,7 @@ List of implemented papers:
 
 ## How to run
 
-Run a simple minimal example here [![Run in Google Colab](https://img.shields.io/static/v1?label=Run%20in&message=Google%20Colab&color=orange&logo=Google%20Cloud)](https://colab.research.google.com/github/atong01/conditional-flow-matching/blob/master/examples/notebooks/training-8gaussians-to-moons.ipynb). Or install the more efficient code locally with these steps.
+Run a simple minimal example here [![Run in Google Colab](https://img.shields.io/static/v1?label=Run%20in&message=Google%20Colab&color=orange&logo=Google%20Cloud)](https://colab.research.google.com/github/atong01/conditional-flow-matching/blob/master/examples/2D_tutorials/tutorial_training_8_gaussians_to_moons.ipynb). Or install the more efficient code locally with these steps.
 
 TorchCFM is now on [pypi](https://pypi.org/project/torchcfm/)! You can install it with:
 


### PR DESCRIPTION
Updated notebook links and paths for examples in README.

## What does this PR do?

When example notebook files got moved, Colab links no longer resolved properly. This PR fixes that.

Fixes #160 and other broken links.

## Before submitting

- [ x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ x] Did you list all the **breaking changes** introduced by this pull request?
- [ x] Did you **test your PR locally** with `pytest` command?
- [o ] Did you **run pre-commit hooks** with `pre-commit run -a` command?  N/A: No code changes were made. Only README.md was changed

## Did you have fun?

Yes. 

Make sure you had fun coding 🙃

## Summary by Sourcery

Documentation:
- Fix README links and paths for the model comparison, MNIST example, and minimal training notebooks so their Colab badges open the correct files.