### PR TITLE
Fix incorrect pairing in sample_plan_with_scipy

### DIFF
--- a/torchcfm/optimal_transport.py
+++ b/torchcfm/optimal_transport.py
@@ -177,8 +177,8 @@ class OTPlanSampler:
         if self.normalize_cost:
             M = M / M.max()
         _, j = scipy.optimize.linear_sum_assignment(M.cpu().numpy())
-        pi_x0 = x0[j]
-        pi_x1 = x1
+        pi_x0 = x0
+        pi_x1 = x1[j]
         return pi_x0, pi_x1
 
     def sample_plan_with_labels(self, x0, x1, y0=None, y1=None, replace=True):


### PR DESCRIPTION
## What does this PR do?

Currently `sample_plan_with_scipy` returns incorrectly paired points due to an indexing bug. Should be 
```
        pi_x0 = x0
        pi_x1 = x1[j]
```
not 
```
       pi_x0 = x0[j]
       pi_x1 = x1
```
## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃

## Summary by Sourcery

Bug Fixes:
- Correct point pairing in sample_plan_with_scipy by applying the assignment indices to the target points instead of the source points.