### PR TITLE
docs(cfm): fix compute_conditional_flow docstring formula (t -> xt in numerator)

### DIFF
--- a/torchcfm/conditional_flow_matching.py
+++ b/torchcfm/conditional_flow_matching.py
@@ -369,7 +369,7 @@ class TargetConditionalFlowMatcher(ConditionalFlowMatcher):
 
     def compute_conditional_flow(self, x0, x1, t, xt):
         """
-        Compute the conditional vector field ut(x1|x0) = (x1 - (1 - sigma) t)/(1 - (1 - sigma)t), see Eq.(21) [2].
+        Compute the conditional vector field ut(x1|x0) = (x1 - (1 - sigma) xt)/(1 - (1 - sigma)t), see Eq.(21) [2].
 
         Parameters
         ----------
@@ -383,7 +383,7 @@ class TargetConditionalFlowMatcher(ConditionalFlowMatcher):
 
         Returns
         -------
-        ut : conditional vector field ut(x1|x0) = (x1 - (1 - sigma) t)/(1 - (1 - sigma)t)
+        ut : conditional vector field ut(x1|x0) = (x1 - (1 - sigma) xt)/(1 - (1 - sigma)t)
 
         References
         ----------


### PR DESCRIPTION
## Summary

\`TargetConditionalFlowMatcher.compute_conditional_flow\` (\`torchcfm/conditional_flow_matching.py\`, lines 370-394) documents the target conditional flow as:

\`\`\`
ut(x1|x0) = (x1 - (1 - sigma) t)/(1 - (1 - sigma)t)
\`\`\`

but the implementation returns:

\`\`\`python
return (x1 - (1 - self.sigma) * xt) / (1 - (1 - self.sigma) * t)
\`\`\`

which matches Eq.(21) of Lipman et al., ICLR 2023 — the numerator uses the position \`xt\`, not the time scalar \`t\`. Updated the summary (line 372) and the Returns description (line 386) so both say:

\`\`\`
ut(x1|x0) = (x1 - (1 - sigma) xt)/(1 - (1 - sigma)t)
\`\`\`

Closes #175

## Testing

Docstring-only change; no runtime paths touched.

## Summary by Sourcery

Documentation:
- Fix the compute_conditional_flow docstring formula so the numerator uses xt instead of t, aligning documentation with the implementation and Eq.(21) of Lipman et al., ICLR 2023.